### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,23 +12,23 @@ Wiegand	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin	        KEYWORD2
-setOneIntPin    KEYWORD2
-setZeroIntPin   KEYWORD2
-attach          KEYWORD2
-available       KEYWORD2
-reset           KEYWORD2
-getCardCode     KEYWORD2
-getFacilityCode KEYWORD2
+begin	KEYWORD2
+setOneIntPin	KEYWORD2
+setZeroIntPin	KEYWORD2
+attach	KEYWORD2
+available	KEYWORD2
+reset	KEYWORD2
+getCardCode	KEYWORD2
+getFacilityCode	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-WIEGAND_DEBUG              LITERAL1
-WIEGAND_DEBUG_READER_BITS  LITERAL1
-WIEGAND_WAIT_TIME          LITERAL1
-WIEGAND_MAX_BITS           LITERAL1
+WIEGAND_DEBUG	LITERAL1
+WIEGAND_DEBUG_READER_BITS	LITERAL1
+WIEGAND_WAIT_TIME	LITERAL1
+WIEGAND_MAX_BITS	LITERAL1
 
 #######################################
 # Built in variables (LITERAL2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords